### PR TITLE
fix: Correct broken link in RESOURCES.md

### DIFF
--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -55,7 +55,7 @@ This document provides official documentation and learning resources for each ch
 
 ### Challenge 6: Styling the UI
 **Official Documentation:**
-- [Styling and CSS](https://react.dev/learn/writing-markup-with-jsx#adding-styles)
+- [Styling and CSS](https://nextjs.org/docs/app/getting-started/css#css-modules)
 
 **Community Resources:**
 - [CSS Modules Documentation](https://github.com/css-modules/css-modules)

--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -55,7 +55,7 @@ This document provides official documentation and learning resources for each ch
 
 ### Challenge 6: Styling the UI
 **Official Documentation:**
-- [Styling and CSS](https://react.dev/learn/style-and-css)
+- [Styling and CSS](https://react.dev/learn/writing-markup-with-jsx#adding-styles)
 
 **Community Resources:**
 - [CSS Modules Documentation](https://github.com/css-modules/css-modules)


### PR DESCRIPTION
I found the https://react.dev/learn/style-and-css link was broken, and found a replacement at https://react.dev/learn/writing-markup-with-jsx#adding-styles.